### PR TITLE
Add support for fuzzing

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+
+[package]
+name = "lodepng-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.lodepng]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_target_1"
+path = "fuzz_targets/fuzz_target_1.rs"

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate lodepng;
+
+fuzz_target!(|data: &[u8]| {
+    lodepng::decode32(data);
+});


### PR DESCRIPTION
 - Bypass crc32 and adler32 checks via conditional compilation when lodepng is compiled with fuzzing instrumentation. This lets random input from fuzzers actually reach interesting decoding code instead of being rejected early on due to checksum mismatch.
 - Add fuzzing harness for `cargo-fuzz` that was used to discover #28

If you do not wish to have "fuzz" folder within the project, I can put it in https://github.com/rust-fuzz/targets repository instead.