### PR TITLE
Add wasm32 implementation for libc

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -8,10 +8,17 @@ use std::slice;
 use std::fmt;
 use std::os::raw::{c_char, c_uint, c_long, c_void};
 use std::ffi::CStr;
-use std::path::*;
 use std::io;
 
 use crate::rustimpl;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod libc;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use std::path::{PathBuf};
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+use std::path::{Path};
 
 macro_rules! lode_error {
     ($e:expr) => {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -8,17 +8,12 @@ use std::slice;
 use std::fmt;
 use std::os::raw::{c_char, c_uint, c_long, c_void};
 use std::ffi::CStr;
+use std::path::*;
 use std::io;
 
 use crate::rustimpl;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod libc;
-
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-use std::path::PathBuf;
-
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-use std::path::Path;
 
 macro_rules! lode_error {
     ($e:expr) => {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -15,10 +15,10 @@ use crate::rustimpl;
 mod libc;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-use std::path::{PathBuf};
+use std::path::PathBuf;
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-use std::path::{Path};
+use std::path::Path;
 
 macro_rules! lode_error {
     ($e:expr) => {

--- a/src/ffi/libc.rs
+++ b/src/ffi/libc.rs
@@ -1,0 +1,36 @@
+pub type size_t = usize;
+
+const MALLOC_HEADER : isize = 8;
+const MALLOC_ALIGN : usize = 8;
+
+use super::c_void;
+use std::alloc::{self, Layout};
+use std::ptr;
+
+pub unsafe fn malloc(size: size_t) -> *mut c_void {
+    let lay = Layout::from_size_align_unchecked(MALLOC_HEADER as usize + size, MALLOC_ALIGN);
+    let p = alloc::alloc(lay);
+    if p.is_null() {
+        return ptr::null_mut();
+    }
+    *(p as *mut size_t) = size;
+    p.offset(MALLOC_HEADER) as *mut c_void
+}
+pub unsafe fn free(p: *mut c_void) {
+    let p = p.offset(-MALLOC_HEADER) as *mut u8;
+    let size = *(p as *mut size_t);
+    let lay = Layout::from_size_align_unchecked(MALLOC_HEADER as usize + size, MALLOC_ALIGN);
+    alloc::dealloc(p, lay);
+}
+pub unsafe fn realloc(p: *mut c_void, _size: size_t) -> *mut c_void {
+    let p = p.offset(-MALLOC_HEADER) as *mut u8;
+    let size = *(p as *mut size_t);
+    let lay = Layout::from_size_align_unchecked(MALLOC_HEADER as usize + size, MALLOC_ALIGN);
+    let p = alloc::realloc(p, lay, size);
+    if p.is_null() {
+        return ptr::null_mut();
+    }
+    *(p as *mut size_t) = size;
+    p.offset(MALLOC_HEADER) as *mut c_void
+}
+


### PR DESCRIPTION
Fixes #43 . 

This adds a wasm32 implementation for `free`, `malloc` and `realloc`.
Originally written by @rodrigorc in
https://github.com/rust-lang/libc/pull/1092 and adapted.

Disclaimer: I don't know rust, and I haven't really looked at the implementation; I blindly copy-pasted. This should probably be reviewed before it goes in.

