### PR TITLE
Fix ordering of `palette_clear` call.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,12 +72,12 @@ impl ColorMode {
 
     /// Set color depth to 8-bit palette and set the colors
     pub fn set_palette(&mut self, palette: &[RGBA]) -> Result<(), Error> {
+        self.palette_clear();
         for &c in palette {
             self.palette_add(c)?;
         }
         self.colortype = ColorType::PALETTE;
         self.set_bitdepth(8);
-        self.palette_clear();
         Ok(())
     }
 


### PR DESCRIPTION
This appears to be a simple inverted order bug.

When the clear call is at the end, the palette is empty when encoding happens.

Fixes #54.