### PR TITLE
Fix feature = "cargo-clippy" deprecation

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::needless_borrow))]
+#![cfg_attr(clippy, allow(clippy::needless_borrow))]
 #![allow(clippy::missing_safety_doc)]
 #![allow(non_upper_case_globals)]
 

--- a/src/ffi/functions.rs
+++ b/src/ffi/functions.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::needless_borrow))]
+#![cfg_attr(clippy, allow(clippy::needless_borrow))]
 #![allow(clippy::missing_safety_doc)]
 #![allow(non_upper_case_globals)]
 


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html